### PR TITLE
Option to keep orgid

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Where:
 - `--port`: Port used to expose this proxy.
 - `--loki-server`: URL of your grafana loki instance.
 - `--auth-config`: Authentication configuration file path.
+- `--keep-orgid`: Don't change OrgID header.
 
 #### Configure the proxy
 

--- a/cmd/loki-multi-tenant-proxy/main.go
+++ b/cmd/loki-multi-tenant-proxy/main.go
@@ -40,6 +40,9 @@ func main() {
 					Name:  "auth-config",
 					Usage: "AuthN yaml configuration file path",
 					Value: "authn.yaml",
+				}, cli.BoolFlag{
+					Name:  "keep-orgid",
+					Usage: "Don't change OrgID header (proxy is only used for authent)",
 				},
 			},
 		},

--- a/internal/app/loki-multi-tenant-proxy/auth.go
+++ b/internal/app/loki-multi-tenant-proxy/auth.go
@@ -33,11 +33,11 @@ func BasicAuth(handler http.HandlerFunc, authConfig *pkg.Authn) http.HandlerFunc
 func isAuthorized(user string, pass string, authConfig *pkg.Authn) (bool, string) {
 	for _, v := range authConfig.Users {
 		if subtle.ConstantTimeCompare([]byte(user), []byte(v.Username)) == 1 && subtle.ConstantTimeCompare([]byte(pass), []byte(v.Password)) == 1 {
-            if authConfig.KeepOrgID==false {
-			    return true, v.OrgID
-            } else {
-                return true, ""
-            }
+			if authConfig.KeepOrgID == false {
+				return true, v.OrgID
+			} else {
+				return true, ""
+			}
 
 		}
 	}

--- a/internal/app/loki-multi-tenant-proxy/auth.go
+++ b/internal/app/loki-multi-tenant-proxy/auth.go
@@ -33,7 +33,12 @@ func BasicAuth(handler http.HandlerFunc, authConfig *pkg.Authn) http.HandlerFunc
 func isAuthorized(user string, pass string, authConfig *pkg.Authn) (bool, string) {
 	for _, v := range authConfig.Users {
 		if subtle.ConstantTimeCompare([]byte(user), []byte(v.Username)) == 1 && subtle.ConstantTimeCompare([]byte(pass), []byte(v.Password)) == 1 {
-			return true, v.OrgID
+            if authConfig.KeepOrgID==false {
+			    return true, v.OrgID
+            } else {
+                return true, ""
+            }
+
 		}
 	}
 	return false, ""

--- a/internal/app/loki-multi-tenant-proxy/reverse.go
+++ b/internal/app/loki-multi-tenant-proxy/reverse.go
@@ -20,5 +20,7 @@ func modifyRequest(r *http.Request, lokiServerURL *url.URL) {
 	r.Host = lokiServerURL.Host
 	orgID := r.Context().Value(OrgIDKey)
 	r.Header.Set("X-Forwarded-Host", r.Host)
-	r.Header.Set("X-Scope-OrgID", orgID.(string))
+    if orgID != "" {
+	    r.Header.Set("X-Scope-OrgID", orgID.(string))
+    }
 }

--- a/internal/app/loki-multi-tenant-proxy/server.go
+++ b/internal/app/loki-multi-tenant-proxy/server.go
@@ -17,6 +17,7 @@ func Serve(c *cli.Context) error {
 	serveAt := fmt.Sprintf(":%d", c.Int("port"))
 	authConfigLocation := c.String("auth-config")
 	authConfig, _ := pkg.ParseConfig(&authConfigLocation)
+    authConfig.KeepOrgID = c.Bool("keep-orgid")
 
 	http.HandleFunc("/", createHandler(lokiServerURL, authConfig))
 	if err := http.ListenAndServe(serveAt, nil); err != nil {

--- a/internal/app/loki-multi-tenant-proxy/server.go
+++ b/internal/app/loki-multi-tenant-proxy/server.go
@@ -17,7 +17,7 @@ func Serve(c *cli.Context) error {
 	serveAt := fmt.Sprintf(":%d", c.Int("port"))
 	authConfigLocation := c.String("auth-config")
 	authConfig, _ := pkg.ParseConfig(&authConfigLocation)
-    authConfig.KeepOrgID = c.Bool("keep-orgid")
+	authConfig.KeepOrgID = c.Bool("keep-orgid")
 
 	http.HandleFunc("/", createHandler(lokiServerURL, authConfig))
 	if err := http.ListenAndServe(serveAt, nil); err != nil {

--- a/internal/pkg/config.go
+++ b/internal/pkg/config.go
@@ -9,7 +9,7 @@ import (
 // Authn Contains a list of users
 type Authn struct {
 	Users     []User `yaml:"users"`
-    KeepOrgID bool
+	KeepOrgID bool
 }
 
 // User Identifies a user including the tenant

--- a/internal/pkg/config.go
+++ b/internal/pkg/config.go
@@ -8,7 +8,8 @@ import (
 
 // Authn Contains a list of users
 type Authn struct {
-	Users []User `yaml:"users"`
+	Users     []User `yaml:"users"`
+    KeepOrgID bool
 }
 
 // User Identifies a user including the tenant


### PR DESCRIPTION
Use case:
* we want to enforce orgid on read, so people can't read other people's logs
* but we want write path to allow orgid override, so it's easier for client-side creds management
* we want all auth to be managed with the same app (loki-multi-tenant-proxy)

With this patch, we can have:
* read path proxy with classic settings
* write path proxy with `--keep-orgid`

Orgid will be installation name, and we will manually manage it on multi-tenant-proxy setup for the moment.
This is a "protoduction" hack, we expect it to be replaced with something better once we better understand our use cases.

@paurosello, as you're maintainer of the upstream version: do you think this makes sense to push this upstream? Or would it go against its "simple example" goal?


Towards https://github.com/giantswarm/giantswarm/issues/22396