### PR TITLE
Rename image to distinguish from upstream

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ workflows:
       - architect/push-to-docker:
           context: "architect"
           name: push-to-docker.io
-          image: "docker.io/giantswarm/loki-multi-tenant-proxy"
+          image: "docker.io/giantswarm/loki-multi-tenant-proxy-gs"
           username_envar: "DOCKER_USERNAME"
           password_envar: "DOCKER_PASSWORD"
           dockerfile: "build/package/Dockerfile-with-tests"
@@ -34,7 +34,7 @@ workflows:
       - architect/push-to-docker:
           context: "architect"
           name: push-to-quay.io
-          image: "quay.io/giantswarm/loki-multi-tenant-proxy"
+          image: "quay.io/giantswarm/loki-multi-tenant-proxy-gs"
           username_envar: "QUAY_USERNAME"
           password_envar: "QUAY_PASSWORD"
           dockerfile: "build/package/Dockerfile-with-tests"
@@ -48,7 +48,7 @@ workflows:
       - architect/push-to-docker:
           context: "architect"
           name: push-to-aliyun
-          image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/loki-multi-tenant-proxy"
+          image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/loki-multi-tenant-proxy-gs"
           username_envar: "ALIYUN_USERNAME"
           password_envar: "ALIYUN_PASSWORD"
           dockerfile: "build/package/Dockerfile-with-tests"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - changed: add '--keep-orgid' option
+- changed: image renamed to loki-multi-tenant-proxy-gs
 - changed: Setup CI
 
 [Unreleased]: https://github.com/giantswarm/{APP-NAME}/tree/main


### PR DESCRIPTION
This PR:

- Renames image from `loki-multi-tenant-proxy` to `loki-multi-tenant-proxy-gs` so we don't mix upstream and giantswarm images.

### Checklist

- [x] Update changelog in CHANGELOG.md.
