### PR TITLE
Allow config autoreload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow reload of config via the `/-/reload` endpoint.
+
 ## [0.3.0] - 2024-02-08
 
 ### Added

--- a/internal/app/loki-multi-tenant-proxy/auth/oauth_auth.go
+++ b/internal/app/loki-multi-tenant-proxy/auth/oauth_auth.go
@@ -73,7 +73,7 @@ func extractPayload(token string) (Payload, error) {
 	// Get payload section from the token
 	sections := strings.Split(token, ".")
 	if len(sections) <= 1 {
-		return Payload{}, errors.New("Invalid token")
+		return Payload{}, errors.New("invalid token")
 	}
 	payload := sections[1]
 	payloadDecoded, err := b64.RawURLEncoding.DecodeString(payload)
@@ -93,7 +93,7 @@ func validate(token string, payload Payload, ctx context.Context) error {
 		return errors.New("OAUTH_PROVIDER_URL environment variable not set")
 	}
 	if oauthUrl != payload.Issuer {
-		return fmt.Errorf("Invalid issuer %s, expected issuer %s", payload.Issuer, oauthUrl)
+		return fmt.Errorf("invalid issuer %s, expected issuer %s", payload.Issuer, oauthUrl)
 	}
 	// Initialize a provider by specifying dex's issuer URL.
 	provider, err := oidc.NewProvider(ctx, payload.Issuer)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29580

This PR:

- adds a `reload` endpoint to the multi-tenant proxy to be able to reload it's config when the configmap or secret changed

### Checklist

- [x] Update changelog in CHANGELOG.md.
